### PR TITLE
new version display

### DIFF
--- a/OXRS-SHA-StateMonitor-ESP32-FW.ino
+++ b/OXRS-SHA-StateMonitor-ESP32-FW.ino
@@ -106,19 +106,23 @@ void setup()
   Wire.setClock(I2C_CLOCK_SPEED);
 
   // Display the firmware version and initialise the port display
-  screen.draw_logo(FW_VERSION);
+  screen.draw_logo(FW_NAME, FW_VERSION);
   screen.draw_ports(g_mcps_found);
 
   // Set up ethernet and obtain an IP address
   byte mac[6];
   initialiseEthernet(mac);
+  
+  // Display IP and MAC addresses on screen
+  screen.show_IP(Ethernet.localIP());
+  screen.show_MAC(mac);
 
   // Set up connection to MQTT broker
   initialiseMqtt(mac);
 
-  // Display IP and MAC addresses on screen
-  screen.show_IP(Ethernet.localIP());
-  screen.show_MAC(mac);
+  // Display MQTT topic and RACK temperature on screen
+  screen.show_MQTT_topic("MQTT-topic TBD ????");     // need to find out how to get topic
+  screen.show_rack_temp(12.3456);               // for test now. value will be replaced by measured tempereture
 }
 
 /**


### PR DESCRIPTION
requires updated OXRS_LCD library

Please update the OXRS_LCD lib from my repro. Wanted to wait for getting access to the lib on SuperHouse before changing my local workflow.

This PR together with the updated OXRS_LCD lib should address the version display issue together with the TFT_eSPI configuration.

I generated a proportional font that allows to print much more character into one line while keeping the hight of the font the same.

![NewVersionDisplay](https://user-images.githubusercontent.com/53935853/132133494-3ecdda13-0a88-41c9-b783-61319ac850ed.JPG)

I also would like to show the mqtt topic but the function to get this is private. If you like the idea to show the (conf ?)topic please help.

Rack Temp. shall be filled in and updated periodically by readings from the onboard sensor. Only a test placeholder for now.