### PR TITLE
Fix mqtt config

### DIFF
--- a/OXRS-SHA-StateMonitor-ESP32-FW.ino
+++ b/OXRS-SHA-StateMonitor-ESP32-FW.ino
@@ -59,7 +59,7 @@
 uint8_t g_mcps_found = 0;
 
 // temperature update interval timer
-uint32_t g_last_temp_update = -TEMP_UPDATE_INTERVAL;
+uint32_t g_last_temp_update = -TEMP_UPDATE_INTERVAL_MS;
 
 /*--------------------------- Function Signatures ------------------------*/
 void mqttCallback(char * topic, byte * payload, int length);
@@ -158,7 +158,7 @@ void loop()
 
 void updateTemperature()
 {
-  if ((millis() - g_last_temp_update) > TEMP_UPDATE_INTERVAL)
+  if ((millis() - g_last_temp_update) > TEMP_UPDATE_INTERVAL_MS)
   {
     // TODO: read temp from onboard sensor
     float temperature;

--- a/OXRS-SHA-StateMonitor-ESP32-FW.ino
+++ b/OXRS-SHA-StateMonitor-ESP32-FW.ino
@@ -182,15 +182,10 @@ void initialiseMqtt(byte * mac)
   // Set the MQTT client id to the f/w code + MAC address
   mqtt.setClientId(FW_CODE, mac);
 
-#ifdef MQTT_USERNAME
-  mqtt.setAuth(MQTT_USERNAME, MQTT_PASSWORD);
-#endif
-#ifdef MQTT_TOPIC_PREFIX
-  mqtt.setTopicPrefix(MQTT_TOPIC_PREFIX);
-#endif
-#ifdef MQTT_TOPIC_SUFFIX
-  mqtt.setTopicSuffix(MQTT_TOPIC_SUFFIX);
-#endif
+  // Set credentials and any extra topic parts specified
+  if (MQTT_USERNAME     != NULL) { mqtt.setAuth(MQTT_USERNAME, MQTT_PASSWORD); }
+  if (MQTT_TOPIC_PREFIX != NULL) { mqtt.setTopicPrefix(MQTT_TOPIC_PREFIX); }
+  if (MQTT_TOPIC_SUFFIX != NULL) { mqtt.setTopicSuffix(MQTT_TOPIC_SUFFIX); }
 
   // Display the MQTT topic on screen
   char topic[64];
@@ -487,10 +482,7 @@ void scanI2CBus()
 void initialiseEthernet(byte * ethernet_mac)
 {
   // Determine MAC address
-#ifdef STATIC_MAC
-  Serial.print(F("Using static MAC address: "));
-  memcpy(ethernet_mac, STATIC_MAC, sizeof(ethernet_mac));
-#elif ARDUINO_ARCH_ESP32
+#if ARDUINO_ARCH_ESP32
   Serial.print(F("Getting Ethernet MAC address from ESP32: "));
   WiFi.macAddress(ethernet_mac);  // Temporarily populate Ethernet MAC with ESP32 Base MAC
   ethernet_mac[5] += 3;           // Ethernet MAC is Base MAC + 3 (see https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/system.html#mac-address)
@@ -528,13 +520,8 @@ void initialiseEthernet(byte * ethernet_mac)
 #endif
 
   // Obtain IP address
-#ifdef STATIC_IP
-  Serial.print(F("Using static IP address: "));
-  Ethernet.begin(ethernet_mac, STATIC_IP, STATIC_DNS);
-#else
   Serial.print(F("Getting IP address via DHCP: "));
   Ethernet.begin(ethernet_mac, 10000);
-#endif
 
   // Display IP address on serial
   Serial.println(Ethernet.localIP());

--- a/config.h.example
+++ b/config.h.example
@@ -10,7 +10,7 @@ const char *  MQTT_PASSWORD         = NULL;                 // Optional, NULL if
 const char *  MQTT_TOPIC_PREFIX     = NULL;                 // Optional, NULL if no prefix in topic path
 const char *  MQTT_TOPIC_SUFFIX     = NULL;                 // Optional, NULL if no suffix in topic path
 
-#define       TEMP_UPDATE_INTERVAL    60000L                // Read and publish temp (milliseconds)
+#define       TEMP_UPDATE_INTERVAL_MS 60000L                // Read and publish temp (milliseconds)
 
 /* ----------------- Hardware-specific config ---------------------- */
 /* Serial */

--- a/config.h.example
+++ b/config.h.example
@@ -10,7 +10,7 @@ const char *  MQTT_PASSWORD         = NULL;                 // Optional, NULL if
 const char *  MQTT_TOPIC_PREFIX     = NULL;                 // Optional, NULL if no prefix in topic path
 const char *  MQTT_TOPIC_SUFFIX     = NULL;                 // Optional, NULL if no suffix in topic path
 
-#define       TEMP_UPDATE_INTERVAL    60000L                // How often the temperature sensor is read and published
+#define       TEMP_UPDATE_INTERVAL    60000L                // Read and publish temp (milliseconds)
 
 /* ----------------- Hardware-specific config ---------------------- */
 /* Serial */
@@ -28,17 +28,9 @@ const uint8_t MCP_COUNT             = sizeof(MCP_I2C_ADDRESS);
 #define       ETHERNET_CS_PIN         26                    // Rack32 (ESP32) with W5500
 #define       WIZNET_RESET_PIN        13                    // Comment out if no Wiznet reset pin
 
-/* Optional, otherwise get MAC from ESP32 (or DEADBEEFFEED for non-ESP32) */
-//const byte    STATIC_MAC[]          = { 0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED };
-
-/* Optional, otherwise get IP/DNS from DHCP */
-//const byte    STATIC_IP[]           = { 192, 168, 1, 35 };
-//const byte    STATIC_DNS[]          = { 192, 168, 1, 1 };
-
 /* NOTE: If using an EtherMega (ATmega2560) with W5100;
  *  - Set ETHERNET_CS_PIN to 10 
  *  - Comment out WIZNET_RESET_PIN
- *  - Uncomment STATIC_MAC
  */
  
 #endif


### PR DESCRIPTION
My original code was broken - I knew it was too good to be true (it working first time, untested!).

My `#ifdef` checks around `MQTT_USERNAME` etc was never going to work as they are not `#defines` but static constants.

So I have changed the MQTT initialisation code so it now works, testing for NULL rather than `#ifdef`.

I have also removed the `STATIC_XXX` config options for now - are you happy with this? We could add them back in if we think they are needed, and add back the `ENABLE_DHCP` defines etc. But I just figured they are very unlikely to be used, and once we get this admin UI working it can all be handled via that anyway.

FYI - I have pushed PRs to the StateMonitor, StateController and SmokeDetector firmwares with the same changes.