### PR TITLE
use build flags to configure TFT_eSPI

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -22,6 +22,7 @@ framework = arduino
 board = esp32dev
 lib_deps = 
   adafruit/Adafruit MCP23017 Arduino Library
+	bodmer/TFT_eSPI
 	https://github.com/OXRS-IO/Ethernet
 	https://github.com/OXRS-IO/OXRS-IO-MQTT-ESP32-LIB
 	https://github.com/OXRS-IO/OXRS-IO-API-ESP32-LIB
@@ -29,11 +30,11 @@ lib_deps =
 	https://github.com/OXRS-IO/OXRS-IO-IOHandler-ESP32-LIB
 	https://github.com/SuperHouse/OXRS-SHA-Rack32-ESP32-LIB
 	https://github.com/androbi-com/MqttLogger
-	TFT_eSPI
 build_flags = 
 	-DFW_NAME="${firmware.name}"
 	-DFW_SHORT_NAME="${firmware.short_name}"
 	-DFW_MAKER="${firmware.maker}"
+
 	; TFT_eSPI configuration
 	-DUSER_SETUP_LOADED=1                        
 	-DST7789_2_DRIVER=1    		
@@ -47,7 +48,6 @@ build_flags =
 	-DTFT_RST=4 
 	-DTFT_BL=14  
 	-DSPI_FREQUENCY=40000000
-
 	-DLOAD_GLCD=1   ; Font 1. Original Adafruit 8 pixel font needs ~1820 bytes in FLASH
 	-DLOAD_FONT2=1 	; Font 2. Small 16 pixel high font, needs ~3534 bytes in FLASH, 96 characters
 	-DLOAD_GFXFF=1  ; FreeFonts. Include access to the 48 Adafruit_GFX free fonts FF1 to FF48 and custom fonts

--- a/platformio.ini
+++ b/platformio.ini
@@ -23,7 +23,6 @@ board = esp32dev
 lib_deps = 
   adafruit/Adafruit MCP23017 Arduino Library
 	https://github.com/OXRS-IO/Ethernet
-	https://github.com/OXRS-IO/TFT_eSPI
 	https://github.com/OXRS-IO/OXRS-IO-MQTT-ESP32-LIB
 	https://github.com/OXRS-IO/OXRS-IO-API-ESP32-LIB
 	https://github.com/OXRS-IO/OXRS-IO-LCD-ESP32-LIB

--- a/platformio.ini
+++ b/platformio.ini
@@ -30,10 +30,29 @@ lib_deps =
 	https://github.com/OXRS-IO/OXRS-IO-IOHandler-ESP32-LIB
 	https://github.com/SuperHouse/OXRS-SHA-Rack32-ESP32-LIB
 	https://github.com/androbi-com/MqttLogger
+	TFT_eSPI
 build_flags = 
 	-DFW_NAME="${firmware.name}"
 	-DFW_SHORT_NAME="${firmware.short_name}"
 	-DFW_MAKER="${firmware.maker}"
+	; TFT_eSPI configuration
+	-DUSER_SETUP_LOADED=1                        
+	-DST7789_2_DRIVER=1    		
+	-DTFT_RGB_ORDER=TFT_RGB  
+	-DTFT_WIDTH=240 	
+	-DTFT_HEIGHT=240 	
+	-DTFT_MOSI=23 
+	-DTFT_SCLK=18
+	-DTFT_CS=25
+	-DTFT_DC=2
+	-DTFT_RST=4 
+	-DTFT_BL=14  
+	-DSPI_FREQUENCY=40000000
+
+	-DLOAD_GLCD=1   ; Font 1. Original Adafruit 8 pixel font needs ~1820 bytes in FLASH
+	-DLOAD_FONT2=1 	; Font 2. Small 16 pixel high font, needs ~3534 bytes in FLASH, 96 characters
+	-DLOAD_GFXFF=1  ; FreeFonts. Include access to the 48 Adafruit_GFX free fonts FF1 to FF48 and custom fonts
+
 
 ; debug builds
 [env:debug-eth]


### PR DESCRIPTION
configure TFT_eSPI via build_flags
that removes the need to host a customised version of the TFT_eSPI library on OXRS-IO  (can be removed)