### PR TITLE
add debug build for room8266-wifi

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -47,13 +47,6 @@ build_flags =
 	-DFW_VERSION="DEBUG-ETH"
 monitor_speed = 115200
 
-[env:room8266-debug-wifi]
-extends = room8266-wifi
-build_flags = 
-	${room8266-wifi.build_flags}
-	-DFW_VERSION="DEBUG-WIFI"
-monitor_speed = 115200
-
 ; release builds
 [env:rack32-eth]
 extends = rack32
@@ -77,7 +70,16 @@ extends = room8266
 extra_scripts = pre:release_extra.py
 
 [env:room8266-wifi]
-extends = room8266-wifi
+extends = room8266
+lib_deps = 
+	${room8266.lib_deps}
+	DNSServer
+	ESP8266WiFi
+	ESP8266WebServer
+	https://github.com/tzapu/wifiManager
+build_flags = 
+	${room8266.build_flags}
+	-DWIFI_MODE
 extra_scripts = pre:release_extra.py
 
 [rack32]
@@ -120,15 +122,3 @@ lib_deps =
 build_flags = 
 	${env.build_flags}
 	-DOXRS_ROOM8266
-
-[room8266-wifi]
-extends = room8266
-lib_deps = 
-	${room8266.lib_deps}
-	DNSServer
-	ESP8266WiFi
-	ESP8266WebServer
-	https://github.com/tzapu/wifiManager
-build_flags = 
-	${room8266.build_flags}
-	-DWIFI_MODE

--- a/platformio.ini
+++ b/platformio.ini
@@ -40,11 +40,39 @@ build_flags =
 	-DFW_VERSION="DEBUG-ETH"
 monitor_speed = 115200
 
+[env:rack32-debug-wifi]
+extends = rack32
+lib_deps = 
+	${rack32.lib_deps}
+	DNSServer
+	WiFi
+	WebServer
+	https://github.com/tzapu/wifiManager
+build_flags = 
+	${rack32.build_flags}
+	-DWIFI_MODE
+	-DFW_VERSION="DEBUG-WIFI"
+monitor_speed = 115200
+
 [env:room8266-debug]
 extends = room8266
 build_flags = 
 	${room8266.build_flags}
 	-DFW_VERSION="DEBUG-ETH"
+monitor_speed = 115200
+
+[env:room8266-debug-wifi]
+extends = room8266
+lib_deps = 
+	${room8266.lib_deps}
+	DNSServer
+	ESP8266WiFi
+	ESP8266WebServer
+	https://github.com/tzapu/wifiManager
+build_flags = 
+	${room8266.build_flags}
+	-DWIFI_MODE
+	-DFW_VERSION="DEBUG-WIFI"
 monitor_speed = 115200
 
 ; release builds

--- a/platformio.ini
+++ b/platformio.ini
@@ -47,6 +47,13 @@ build_flags =
 	-DFW_VERSION="DEBUG-ETH"
 monitor_speed = 115200
 
+[env:room8266-debug-wifi]
+extends = room8266-wifi
+build_flags = 
+	${room8266-wifi.build_flags}
+	-DFW_VERSION="DEBUG-WIFI"
+monitor_speed = 115200
+
 ; release builds
 [env:rack32-eth]
 extends = rack32
@@ -70,16 +77,7 @@ extends = room8266
 extra_scripts = pre:release_extra.py
 
 [env:room8266-wifi]
-extends = room8266
-lib_deps = 
-	${room8266.lib_deps}
-	DNSServer
-	ESP8266WiFi
-	ESP8266WebServer
-	https://github.com/tzapu/wifiManager
-build_flags = 
-	${room8266.build_flags}
-	-DWIFI_MODE
+extends = room8266-wifi
 extra_scripts = pre:release_extra.py
 
 [rack32]
@@ -122,3 +120,15 @@ lib_deps =
 build_flags = 
 	${env.build_flags}
 	-DOXRS_ROOM8266
+
+[room8266-wifi]
+extends = room8266
+lib_deps = 
+	${room8266.lib_deps}
+	DNSServer
+	ESP8266WiFi
+	ESP8266WebServer
+	https://github.com/tzapu/wifiManager
+build_flags = 
+	${room8266.build_flags}
+	-DWIFI_MODE


### PR DESCRIPTION
I added a debug section` [env:room8266-debug-wifi]` to be able to compile it local. The release build section doesn't work local (for me).
Hope I got it right.
