### PR TITLE
use of gpio pins instead MCP io expander

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -54,6 +54,21 @@ build_flags =
 	-DFW_VERSION="DEBUG-WIFI"
 monitor_speed = 115200
 
+[env:rack32-debug-gpio-wifi]
+extends = rack32
+lib_deps = 
+	${rack32.lib_deps}
+	DNSServer
+	WiFi
+	WebServer
+	https://github.com/tzapu/wifiManager
+build_flags = 
+	${rack32.build_flags}
+	-DWIFI_MODE
+	-DUSE_GPIO=1
+	-DFW_VERSION="DEBUG-WIFI"
+monitor_speed = 115200
+
 [env:room8266-debug]
 extends = room8266
 build_flags = 


### PR DESCRIPTION
I played with the `StateMonitor FW` and created a proposal that utilises an alternative of using different I/O hardware.
Here the MCPs are replaced with the 16 usable GPIOs of an ESP32 between GPIO2 and GPIO27 which are transformed into a 16-bit `uint16_t.` This mimics a configuration with one MCP. It offers the full functionality of the OXRS eco system, changes are in `main.cpp` only. None of the API has changed except the index which equals here the GPIO (-> 2,4,5, .... 26,27) for convenience. Shows again the flexibility of our architecture.
This allows to use a very simple piece of HW (just an ESP32 with the GPIOs broken out) to play with the OXRS eco system and get familiar with it. Could motivate more people to jump on. It could also be used to make a very simple `StateMonitor `to be used as a satelite.
This proposal is not ready to go and would need some cleanup, but shows the idea. If this would be rated as usefull, I plan to integrate the `StateController `portion as well as I did for the `StateIO FW`.

Curious to see your comments.